### PR TITLE
fix (ImagesGalleryViewModel): Fix data duplication after pagination

### DIFF
--- a/ImagesGallery/ImagesGallery/App/SceneDelegate.swift
+++ b/ImagesGallery/ImagesGallery/App/SceneDelegate.swift
@@ -24,7 +24,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     networkService: NetworkService(), 
                     helper: ImagesGalleryHelper()
                 ),
-                startPage: .fromZero
+                startPage: .fromFirstPage
             )
         )
     )

--- a/ImagesGallery/ImagesGallery/Constants/ApiURL.swift
+++ b/ImagesGallery/ImagesGallery/Constants/ApiURL.swift
@@ -21,7 +21,7 @@ enum ResultsPerPage: Int {
 }
 
 enum StartPageIndex: Int {
-    case fromZero = 0
+    case fromFirstPage = 1
 }
 
 enum URLRequestValues {

--- a/ImagesGallery/ImagesGallery/ImagesGallery/ImagesGalleryViewModels/ImagesGalleryViewModel.swift
+++ b/ImagesGallery/ImagesGallery/ImagesGallery/ImagesGalleryViewModels/ImagesGalleryViewModel.swift
@@ -103,7 +103,7 @@ private extension ImagesGalleryViewModel {
 
 extension ImagesGalleryViewModel {
     func handleDisplayData(for data: [ImagesGalleryDisplayModel]) {
-        self.imagesGalleryDisplayData += data
+        self.imagesGalleryDisplayData.append(contentsOf: data)
         self.updateImagesGalleryWithStoredState()
         self.imagesGalleryDisplayDataIsReadyForViewPublisher.send()
     }
@@ -114,10 +114,10 @@ extension ImagesGalleryViewModel {
     
     func handleScrolledToItemWithItemIndex(_ index: Int) {
         let lastItemIndex = self.imagesGalleryDisplayData.count - 1
-        
+                
         if index == lastItemIndex {
             self.currentPage += 1
-            
+            self.cancellables.forEach { $0.cancel() }
             self.fetchImagesData(
                 with: .maximum
             )


### PR DESCRIPTION
Fixed with cancelling of subscription on imagesGalleryDisplayDataIsReadyForViewPublisher in ImagesGalleryViewModel which duplicates after fetchImagesData method 2nd time calling

Task: #059